### PR TITLE
Replace uncommon arrows in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,23 +173,23 @@ function urlcat(baseTemplate: string, params: ParamMap): string
 <ul>
   <li>
     <code>urlcat('https://api.example.com', '/users/:id/posts', { id: 123, limit: 10, offset: 120 })</code><br>
-    ⮡ <code>'https://api.example.com/users/123/posts?limit=10&offset=120'</code>
+    → <code>'https://api.example.com/users/123/posts?limit=10&offset=120'</code>
   </li>
   <li>
     <code>urlcat('http://example.com/', '/posts/:title', { title: 'Letters & "Special" Characters' })</code><br>
-    ⮡ <code>'http://example.com/posts/Letters%20%26%20%22Special%22%20Characters'</code>
+    → <code>'http://example.com/posts/Letters%20%26%20%22Special%22%20Characters'</code>
   </li>
   <li>
     <code>urlcat('https://api.example.com', '/users')</code><br>
-    ⮡ <code>'https://api.example.com/users'</code>
+    → <code>'https://api.example.com/users'</code>
   </li>
   <li>
     <code>urlcat('https://api.example.com/', '/users')</code><br>
-    ⮡ <code>'https://api.example.com/users'</code>
+    → <code>'https://api.example.com/users'</code>
   </li>
   <li>
     <code>urlcat('http://example.com/', '/users/:userId/posts/:postId/comments', { userId: 123, postId: 987, authorId: 456, limit: 10, offset: 120 })</code><br>
-    ⮡ <code>'http://example.com/users/123/posts/987/comments?authorId=456&limit=10&offset=120'</code>
+    → <code>'http://example.com/users/123/posts/987/comments?authorId=456&limit=10&offset=120'</code>
   </li>
 </ul>
 


### PR DESCRIPTION
Hi, I found that the character “⮡” in README cannot display properly in macOS. So I replaced it with normal arrows. Feel free to propose any other symbols.

Here are some screenshots in different browsers.

![image](https://user-images.githubusercontent.com/2239547/94288600-289a6c00-ff8a-11ea-9eec-9c8e510680d5.png)

![image](https://user-images.githubusercontent.com/2239547/94288701-4bc51b80-ff8a-11ea-80d4-9be42ab90a7c.png)

![image](https://user-images.githubusercontent.com/2239547/94290939-811f3880-ff8d-11ea-9a84-c519c9a490a6.png)


