### PR TITLE
Fails if the baseUrl includes a port number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ function path(template: string, params: ParamMap) {
 
   const renderedPath = template.replace(/:\w+/g, p => {
     const key = p.slice(1);
+    if ( /^\d+$/.test( key ) ) return p;
     if (!params.hasOwnProperty(key)) {
       throw new Error(`Missing value for path parameter ${key}.`);
     }

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -127,6 +127,12 @@ describe('urlcat', () => {
     expect(actual).to.equal(expected);
   });
 
+  it('Ignores entirely numeric path params', () => {
+    const expected = 'http://localhost:3000/path/test';
+    const actual = urlcat('http://localhost:3000/path/:p', { p: 'test' });
+    expect(actual).to.equal(expected);
+  });
+
   it('Throws if a path param is an object', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: {} }))
       .to.throw(TypeError, "Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");


### PR DESCRIPTION
## Summary

I found this to be an issue:
```
node -e 'require( "urlcat" ).default( "http://localhost:3000/foo/:bar/baz", {} );'
Error: Missing value for path parameter 3000.
```
## Details

I figured just ignoring path params that were entirely numeric was the simplest solution, but if somebody is actually using path params that are numbers then you might want to adjust it a bit.
