### PR TITLE
Deno CI in Travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.all-contributorsrc
+.editorconfig
+.git
+.github
+.gitignore
+
+docs/
+README.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
-language: node_js
-node_js:
-  - lts/*
-  - 14
-  - 13
-  - 12
-  - 11
-  - 10
-script:
-  - npm run lint
-  - npm test
-  - npm run coverage
+matrix:
+  include:
+    - language: node_js
+      node_js:
+        - lts/*
+        - 14
+        - 13
+        - 12
+        - 11
+        - 10
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - language: minimal
+      services:
+        - docker
+      script:
+        - docker build -f Dockerfile.deno -t urlcat-deno .
+        - docker run --rm urlcat-deno run ./src/index.ts
+        - docker run --rm urlcat-deno bundle ./src/index.ts
+        - docker run --rm urlcat-deno lint --unstable src/
+        - docker rmi urlcat-deno

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,32 @@
+language: node_js
 matrix:
   include:
-    - language: node_js
-      node_js:
-        - lts/*
-        - 14
-        - 13
-        - 12
-        - 11
-        - 10
+    - node_js: lts/*
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - node_js: 14
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - node_js: 13
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - node_js: 12
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - node_js: 11
+      script:
+        - npm run lint
+        - npm test
+        - npm run coverage
+    - node_js: 10
       script:
         - npm run lint
         - npm test

--- a/Dockerfile.deno
+++ b/Dockerfile.deno
@@ -1,0 +1,4 @@
+FROM hayd/ubuntu-deno:latest
+COPY ./ /app
+WORKDIR /app
+ENTRYPOINT ["deno"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import qs, {IStringifyOptions} from 'qs';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ParamMap = Record<string, any>;
 export type UrlCatConfiguration = Partial<Pick<IStringifyOptions, 'arrayFormat'> & {objectFormat: Partial<Pick<IStringifyOptions, 'format'>>}>
 
@@ -228,6 +229,6 @@ function removeNullOrUndef(params: ParamMap) {
     }, {} as ParamMap);
 }
 
-function notNullOrUndefined(v: any) {
+function notNullOrUndefined<T>(v: T | null | undefined): v is T {
   return v !== undefined && v !== null;
 }


### PR DESCRIPTION
## Summary

As suggested in issue #43 , it would be nice to have some kind of automation around the Deno runtime remaining compatible with this library. I have some experience with CI tooling and figured I could help extend the current Travis config.

## Details

- Providing build matrix to support multilanguage builds in Travis
- Since no official Docker images exist for Deno yet, using the popular images provided by github.com/hayd/deno-docker
- Custom Dockerfile providing deno runtime with the full project
- New pipeline commands using native deno functionality which:
  - run src/index.ts
  - bundle src/index.ts
  - lint src/index.ts
- Note: No test commands as Deno has its own test framework that would have to replace the existing Jest tests

This provides minimal updates around linting errors (implemented one of the type checking functions using TypeScript type guard syntax and disabled an `any` linting error) as well.