### PR TITLE
feat: Support array and object query parameters and formatting - #6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,6 +1010,12 @@
       "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -4809,10 +4815,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -4953,6 +4958,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "request-promise-core": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
   ],
   "author": "Botond Balazs",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "qs": "^6.9.4"
+  },
   "devDependencies": {
     "@types/jest": "26.0.14",
+    "@types/qs": "^6.9.5",
     "coveralls": "3.1.0",
     "jest": "26.4.2",
     "shx": "0.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export function configure(rootConfig: UrlCatConfiguration) {
     urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams , {...rootConfig, ...config});
 }
 
-function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl?: string, config: UrlCatConfiguration = {}) {
+function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl: string | undefined, config: UrlCatConfiguration) {
   const { renderedPath, remainingParams } = path(pathTemplate, params);
   const cleanParams = removeNullOrUndef(remainingParams);
   const renderedQuery = query(cleanParams, config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export default function urlcat(baseUrlOrTemplate: string, pathTemplateOrParams: 
  * ```
  */
 export function configure(rootConfig: UrlCatConfiguration) {
-  return (baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap = {}, config: UrlCatConfiguration = {}) => 
+  return (baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap = {}, config: UrlCatConfiguration = {}) =>
     urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams , {...rootConfig, ...config});
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
+import qs, {IStringifyOptions} from 'qs';
+
 export type ParamMap = Record<string, any>;
+export type UrlCatConfiguration = Partial<Pick<IStringifyOptions, 'arrayFormat'> & {objectFormat: Partial<Pick<IStringifyOptions, 'format'>>}>
 
 /**
  * Builds a URL using the base template and specified parameters.
@@ -55,23 +58,62 @@ export default function urlcat(baseUrl: string, path: string): string;
  */
 export default function urlcat(baseUrl: string, pathTemplate: string, params: ParamMap): string;
 
-export default function urlcat(baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap = {}): string {
+/**
+ * Concatenates the base URL and the path specified using '/' as a separator.
+ * If a '/' occurs at the concatenation boundary in either parameter, it is removed.
+ * Substitutes path parameters with the properties of the @see params object and appends
+ * unused properties in the path as query params.
+ *
+ * @param {String} baseUrl the first part of the URL
+ * @param {String} path the second part of the URL
+ * @param {Object} params Object with properties that correspond to the :params
+ *   in the base template. Unused properties become query params.
+ * @param {Object} config urlcat configuration object
+ *
+ * @returns {String} URL with path params substituted and query params appended
+ *
+ * @example
+ * ```ts
+ * urlcat('http://api.example.com/', '/users/:id', { id: 42, search: 'foo' }, {objectFormat: {format: 'RFC1738'}})
+ * // -> 'http://api.example.com/users/42?search=foo
+ * ```
+ */
+export default function urlcat(baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap, config: UrlCatConfiguration): string;
+
+export default function urlcat(baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap = {}, config: UrlCatConfiguration = {}): string {
   if (typeof pathTemplateOrParams === 'string') {
     const baseUrl = baseUrlOrTemplate;
     const pathTemplate = pathTemplateOrParams;
     const params = maybeParams;
-    return urlcatImpl(pathTemplate, params, baseUrl);
+    return urlcatImpl(pathTemplate, params, baseUrl, config);
   } else {
     const baseTemplate = baseUrlOrTemplate;
     const params = pathTemplateOrParams;
-    return urlcatImpl(baseTemplate, params);
+    return urlcatImpl(baseTemplate, params, undefined, config);
   }
 }
 
-function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl?: string) {
+/**
+ * Factory function providing a pre configured urlcat function
+ *
+ * @param {Object} config Configuration object for urlcat
+ *
+ * @returns {Function} urlcat decorator function
+ *
+ * @example
+ * ```ts
+ * configure({arrayFormat: 'brackets', objectFormat: {format: 'RFC1738'}})
+ * ```
+ */
+export function configure(rootConfig: UrlCatConfiguration) {
+  return (baseUrlOrTemplate: string, pathTemplateOrParams: string | ParamMap, maybeParams: ParamMap = {}, config: UrlCatConfiguration = {}) => 
+    urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams , {...rootConfig, ...config});
+}
+
+function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl?: string, config: UrlCatConfiguration = {}) {
   const { renderedPath, remainingParams } = path(pathTemplate, params);
   const cleanParams = removeNullOrUndef(remainingParams);
-  const renderedQuery = query(cleanParams);
+  const renderedQuery = query(cleanParams, config);
   const pathAndQuery = join(renderedPath, '?', renderedQuery);
   return baseUrl
     ? join(baseUrl, '/', pathAndQuery)
@@ -82,6 +124,7 @@ function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl?: string) {
  * Creates a query string from the specified object.
  *
  * @param {Object} params an object to convert into a query string.
+ * @param {Object} config configuration to stringify the query params.
  *
  * @returns {String} Query string.
  *
@@ -91,8 +134,13 @@ function urlcatImpl(pathTemplate: string, params: ParamMap, baseUrl?: string) {
  * // -> 'id=42&search=foo'
  * ```
  */
-export function query(params: ParamMap): string {
-  return new URLSearchParams(params).toString();
+export function query(params: ParamMap, config?: UrlCatConfiguration): string {
+  const qsConfiguration: IStringifyOptions = {
+    format: config?.objectFormat?.format ?? 'RFC1738', // RDC1738 is urlcat's current default. Breaking change if default is changed
+    arrayFormat: config?.arrayFormat
+  }
+
+  return qs.stringify(params, qsConfiguration);
 }
 
 /**

--- a/test/configure.ts
+++ b/test/configure.ts
@@ -32,4 +32,12 @@ describe('configure', () => {
     const actual = urlcat('http://example.com/path/:p', { p: 'a b', q: 'b c', c: ['foo', 'bar'] }, undefined, {arrayFormat: 'comma', objectFormat: {format: 'RFC3986'}});
     expect(actual).toBe(expected);
   });
+
+  it('Creates a decorator that supports the 3-parameter overload', () => {
+    const expected = 'http://example.com/path/1';
+    const urlcat = configure({objectFormat: {format: 'RFC1738'}})
+
+    const actual = urlcat('http://example.com/', '/path/:p', { p: 1 });
+    expect(actual).toBe(expected);
+  });
 });

--- a/test/configure.ts
+++ b/test/configure.ts
@@ -1,0 +1,35 @@
+import {configure} from '../src';
+
+describe('configure', () => {
+  it('Should create decorator for urlcat with a configuration', () => {
+    const expected = 'http://example.com/path/a%20b?q=b+c';
+    const urlcat = configure({objectFormat: {format: 'RFC1738'}})
+
+    const actual = urlcat('http://example.com/path/:p', { p: 'a b', q: 'b c' });
+    expect(actual).toBe(expected);
+  });
+
+  it('Should create decorator for urlcat and override with custom configuration configuration', () => {
+    const expected = 'http://example.com/path/a%20b?q=b%20c';
+    const urlcat = configure({objectFormat: {format: 'RFC1738'}})
+
+    const actual = urlcat('http://example.com/path/:p', { p: 'a b', q: 'b c' }, undefined, {objectFormat: {format: 'RFC3986'}});
+    expect(actual).toBe(expected);
+  });
+
+  it('Should create decorator for urlcat with all configuration options', () => {
+    const expected = 'http://example.com/path/a%20b?q=b+c&c=foo&c=bar';
+    const urlcat = configure({objectFormat: {format: 'RFC1738'}, arrayFormat: 'repeat'})
+
+    const actual = urlcat('http://example.com/path/:p', { p: 'a b', q: 'b c', c: ['foo', 'bar'] });
+    expect(actual).toBe(expected);
+  });
+
+  it('Should create decorator for urlcat with all configuration options and override with custom configuration', () => {
+    const expected = 'http://example.com/path/a%20b?q=b%20c&c=foo%2Cbar';
+    const urlcat = configure({objectFormat: {format: 'RFC1738'}, arrayFormat: 'repeat'})
+
+    const actual = urlcat('http://example.com/path/:p', { p: 'a b', q: 'b c', c: ['foo', 'bar'] }, undefined, {arrayFormat: 'comma', objectFormat: {format: 'RFC3986'}});
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

PR follow up from the discussion we had in #6 

## Details

- Added `qs` as dependency
- Create `configure` factory function that returns a decorator function wrapping `urlcat`
- Prevented breaking changes by using RFC1738 space parsing for query parameters
- Add type for the configuration object
- Update/added documentation
- Added tests to validate
