### PR TITLE
Merge path param regexes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,11 +167,8 @@ function path(template: string, params: ParamMap) {
   const remainingParams = { ...params };
   const allowedTypes = ["boolean", "string", "number"];
 
-  const renderedPath = template.replace(/:\w+/g, p => {
+  const renderedPath = template.replace(/:[_A-Za-z][_A-Za-z0-9]*/g, p => {
     const key = p.slice(1);
-    if (/^\d+$/.test(key)) {
-      return p;
-    }
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       throw new Error(`Missing value for path parameter ${key}.`);
     }

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -166,4 +166,14 @@ describe('urlcat', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: "  " }))
       .toThrowError("Path parameter p cannot be an empty string.");
   });
+
+  it('Allows port numbers in path params', () => {
+    expect(urlcat('http://example.com:8080/path/:p', { p: 1 }))
+      .toBe('http://example.com:8080/path/1');
+  });
+
+  it('Ignores path params which start with a number', () => {
+    expect(urlcat('http://example.com:8080/path/:1/:2/:p', { '1': 1, '2': 2, p: 3 }))
+      .toBe('http://example.com:8080/path/:1/:2/3?1=1&2=2');
+  });
 });


### PR DESCRIPTION
There was a separate regex for matching path parameters in general and
for excluding ones that start with a number. I've merged them into a
single regex so param names starting with a number aren't even matched
in the first place so they won't need to be excluded.

This improves readability by reducing noise and it is also a bit more
performant.

I've also added two test cases because this case wasn't covered.