### PR TITLE
ESLint: use single-quoted strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    "node": true
+    'node': true
   },
   root: true,
   parser: '@typescript-eslint/parser',
@@ -14,5 +14,6 @@ module.exports = {
   rules: {
     'object-curly-spacing': ['error', 'always'],
     'array-bracket-spacing': ['error', 'never'],
+    'quotes': ['error', 'single'],
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ export function subst(template: string, params: ParamMap): string {
 
 function path(template: string, params: ParamMap) {
   const remainingParams = { ...params };
-  const allowedTypes = ["boolean", "string", "number"];
+  const allowedTypes = ['boolean', 'string', 'number'];
 
   const renderedPath = template.replace(/:[_A-Za-z][_A-Za-z0-9]*/g, p => {
     const key = p.slice(1);
@@ -178,7 +178,7 @@ function path(template: string, params: ParamMap) {
         `Allowed types are: ${allowedTypes.join(', ')}.`
       );
     }
-    if (typeof params[key] === "string" && params[key].trim() === '') {
+    if (typeof params[key] === 'string' && params[key].trim() === '') {
       throw new Error(`Path parameter ${key} cannot be an empty string.`);
     }
     delete remainingParams[key];

--- a/test/subst.ts
+++ b/test/subst.ts
@@ -52,17 +52,17 @@ describe('subst', () => {
 
   it('Throws if a param is an array', () => {
     expect(() => subst(':p', { p: [] }))
-      .toThrowError("Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type object. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a param is an object', () => {
     expect(() => subst(':p', { p: {} }))
-      .toThrowError("Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type object. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a param is a symbol', () => {
     expect(() => subst(':p', { p: Symbol() }))
-      .toThrowError("Path parameter p cannot be of type symbol. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type symbol. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a param is missing', () => {

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -134,37 +134,37 @@ describe('urlcat', () => {
 
   it('Throws if a path param is an object', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: {} }))
-      .toThrowError("Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type object. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a path param is an array', () => {
     expect(() => urlcat('http://example.com/path/:p/:q', { p: [] }))
-      .toThrowError("Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type object. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a path param is a symbol', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: Symbol() }))
-      .toThrowError("Path parameter p cannot be of type symbol. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type symbol. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a path param is undefined', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: undefined }))
-      .toThrowError("Path parameter p cannot be of type undefined. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type undefined. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a path param is null', () => {
     expect(() => urlcat('http://example.com/path/:p', { p: null }))
-      .toThrowError("Path parameter p cannot be of type object. Allowed types are: boolean, string, number.");
+      .toThrowError('Path parameter p cannot be of type object. Allowed types are: boolean, string, number.');
   });
 
   it('Throws if a path param is an empty string', () => {
-    expect(() => urlcat('http://example.com/path/:p', { p: "" }))
-      .toThrowError("Path parameter p cannot be an empty string.");
+    expect(() => urlcat('http://example.com/path/:p', { p: '' }))
+      .toThrowError('Path parameter p cannot be an empty string.');
   });
 
   it('Throws if a path param contains only whitespace', () => {
-    expect(() => urlcat('http://example.com/path/:p', { p: "  " }))
-      .toThrowError("Path parameter p cannot be an empty string.");
+    expect(() => urlcat('http://example.com/path/:p', { p: '  ' }))
+      .toThrowError('Path parameter p cannot be an empty string.');
   });
 
   it('Allows port numbers in path params', () => {


### PR DESCRIPTION
I've noticed that the string quoting style used in some recent PRs was
inconsistent with the rest of the code. I've fixed those and added an
ESLint rule that will prevent such inconsistencies from being introduced
in the future.
