### PR TITLE
query param output bug solved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,15 @@ export function configure(rootConfig: UrlCatConfiguration) {
     pathTemplateOrParams: string | ParamMap,
     maybeParams: ParamMap = {}, config: UrlCatConfiguration = {}
   ): string =>
-    urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams , { ...rootConfig, ...config });
+    urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams, { ...rootConfig, ...config });
+}
+
+function isValidRenderedPath(renderedPath: string, baseUrl: string, pathAndQuery: string): string {
+  if (renderedPath.length) {
+    return join(baseUrl, '/', pathAndQuery);
+  } else {
+    return join(baseUrl, '?', pathAndQuery);
+  }
 }
 
 function urlcatImpl(
@@ -139,11 +147,9 @@ function urlcatImpl(
   const { renderedPath, remainingParams } = path(pathTemplate, params);
   const cleanParams = removeNullOrUndef(remainingParams);
   const renderedQuery = query(cleanParams, config);
-  const pathAndQuery = join(renderedPath.trim(), '?', renderedQuery);
+  const pathAndQuery = join(renderedPath, '?', renderedQuery);
 
-  return baseUrl
-    ? renderedPath.trim().length ? join(baseUrl, '/', pathAndQuery) : join(baseUrl, '?', pathAndQuery)
-    : pathAndQuery;
+  return baseUrl ? isValidRenderedPath(renderedPath, baseUrl, pathAndQuery) : pathAndQuery;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export function configure(rootConfig: UrlCatConfiguration) {
     urlcat(baseUrlOrTemplate, pathTemplateOrParams, maybeParams, { ...rootConfig, ...config });
 }
 
-function isValidRenderedPath(renderedPath: string, baseUrl: string, pathAndQuery: string): string {
+function joinFullUrl(renderedPath: string, baseUrl: string, pathAndQuery: string): string {
   if (renderedPath.length) {
     return join(baseUrl, '/', pathAndQuery);
   } else {
@@ -149,7 +149,7 @@ function urlcatImpl(
   const renderedQuery = query(cleanParams, config);
   const pathAndQuery = join(renderedPath, '?', renderedQuery);
 
-  return baseUrl ? isValidRenderedPath(renderedPath, baseUrl, pathAndQuery) : pathAndQuery;
+  return baseUrl ? joinFullUrl(renderedPath, baseUrl, pathAndQuery) : pathAndQuery;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,9 +139,10 @@ function urlcatImpl(
   const { renderedPath, remainingParams } = path(pathTemplate, params);
   const cleanParams = removeNullOrUndef(remainingParams);
   const renderedQuery = query(cleanParams, config);
-  const pathAndQuery = join(renderedPath, '?', renderedQuery);
+  const pathAndQuery = join(renderedPath.trim(), '?', renderedQuery);
+
   return baseUrl
-    ? join(baseUrl, '/', pathAndQuery)
+    ? renderedPath.trim().length ? join(baseUrl, '/', pathAndQuery) : join(baseUrl, '?', pathAndQuery)
     : pathAndQuery;
 }
 

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -108,12 +108,6 @@ describe('urlcat', () => {
     expect(actual).toBe(expected);
   });
 
-  it('Escape white space path params', () => {
-    const expected = 'http://example.com/path?p=a';
-    const actual = urlcat('http://example.com/path', ' ', { p: 'a' });
-    expect(actual).toBe(expected);
-  });
-
   it('Renders boolean (true) path params', () => {
     const expected = 'http://example.com/path/true';
     const actual = urlcat('http://example.com/path/:p', { p: true });

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -104,13 +104,13 @@ describe('urlcat', () => {
 
   it('Escape empty path params', () => {
     const expected = 'http://example.com/path?p=a';
-    const actual = urlcat('http://example.com/path', "", { p: 'a' });
+    const actual = urlcat('http://example.com/path', '', { p: 'a' });
     expect(actual).toBe(expected);
   });
 
   it('Escape white space path params', () => {
     const expected = 'http://example.com/path?p=a';
-    const actual = urlcat('http://example.com/path', " ", { p: 'a' });
+    const actual = urlcat('http://example.com/path', ' ', { p: 'a' });
     expect(actual).toBe(expected);
   });
 

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -102,6 +102,18 @@ describe('urlcat', () => {
     expect(actual).toBe(expected);
   });
 
+  it('Escape empty path params', () => {
+    const expected = 'http://example.com/path?p=a';
+    const actual = urlcat('http://example.com/path', "", { p: 'a' });
+    expect(actual).toBe(expected);
+  });
+
+  it('Escape white space path params', () => {
+    const expected = 'http://example.com/path?p=a';
+    const actual = urlcat('http://example.com/path', " ", { p: 'a' });
+    expect(actual).toBe(expected);
+  });
+
   it('Renders boolean (true) path params', () => {
     const expected = 'http://example.com/path/true';
     const actual = urlcat('http://example.com/path/:p', { p: true });
@@ -176,4 +188,6 @@ describe('urlcat', () => {
     expect(urlcat('http://example.com:8080/path/:1/:2/:p', { '1': 1, '2': 2, p: 3 }))
       .toBe('http://example.com:8080/path/:1/:2/3?1=1&2=2');
   });
+
+
 });


### PR DESCRIPTION

@balazsbotond Bro As we have discussed in #103.

I have checked that when we pass empty  `pathTemplate`  it makes wrong format of `baseUrl`. I have made few changes related to that. Let me know if you have better solution regarding this ✌️ .

