### PR TITLE
fix: test implementation on parameters without parameters in path

### DIFF
--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -57,8 +57,8 @@ describe('urlcat', () => {
   });
 
   it('All parameters become query parameters if the path has no parameters', () => {
-    const expected = 'http://example.com/path';
-    const actual = urlcat('http://example.com/', '/path?', {});
+    const expected = 'http://example.com/path?p=1&q=2';
+    const actual = urlcat('http://example.com/', '/path?', { p: 1, q: 2 });
     expect(actual).toBe(expected);
   });
 


### PR DESCRIPTION
Seems like the test was not really implemented, probably just copied
previous test by mistake.

## Summary

Test provided false positive.

## Details

I added test implementation for situation where path is not a template (does not contain `:`'s) but parameters are still present as an argument.
