### PR TITLE
support the "asdf:asdf" URI pattern (via ":var::var" template)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export function subst(template: string, params: ParamMap): string {
 function path(template: string, params: ParamMap) {
   const remainingParams = { ...params };
 
-  const renderedPath = template.replace(/:[_A-Za-z][_A-Za-z0-9]*/g, p => {
+  const renderedPath = template.replace(/:[_A-Za-z]+[_A-Za-z0-9]*/g, p => {  // do not replace "::"
     const key = p.slice(1);
     validatePathParam(params, key);
     delete remainingParams[key];

--- a/test/urlcat.ts
+++ b/test/urlcat.ts
@@ -183,5 +183,9 @@ describe('urlcat', () => {
       .toBe('http://example.com:8080/path/:1/:2/3?1=1&2=2');
   });
 
+  it('Does not replace both colons', () => {
+    expect(urlcat('http::one://example.com:8080/path/:one/:two/:three', { one: 1, two: 2, three: 3 }))
+      .toBe('http:1://example.com:8080/path/1/2/3');
+  });
 
 });


### PR DESCRIPTION
## Summary

I wish to create URI's with the resulting syntax of "part:part:part/part/part", but the regex does not support any way to have the resulting string contain colons.

## Details

I modified the regex to require a letter after a colon.
