### PR TITLE
Fix incorrect info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@
 
 Features:
 - Friendly API
-- No dependencies
-- 0.8 KB minified and gzipped
+- Only [one dependency](https://www.npmjs.com/package/qs)
+- 0.8KB [minified and gzipped](https://bundlephobia.com/package/urlcat@2.0.4)
 - TypeScript types provided
 
 ## Why?


### PR DESCRIPTION
## Summary

- The library has a dependency so the README shouldn't say it is dependency-free.
- Link to Bundlephobia where the minified and gzipped size can be checked.
