### PR TITLE
Add "types" import condition to fix esm type definition file not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "shx rm -rf dist",
     "prebuild": "npm run clean",
     "build": "tsup",
+    "postbuild": "cp dist/index.d.ts dist/index.d.mts",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "coverage": "cat ./coverage/lcov.info | coveralls",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `npm install` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`npm test`).
  5. Format your code using the settings in .editorconfig.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
close https://github.com/balazsbotond/urlcat/issues/248

As of Typescript 4.7, when esmodule applications with `moduleResolution: nodenext` use this library, Typescript cannot find a declaration file for `.mjs` file (https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing).
To fix the problem, add "types" field to import condition.

## Details

<!-- Please provide any further details necessary to review and test your code. -->

### About the problem

Here is example:

`package.json`

```json
{
  "type": "module",
  "dependencies": {
    "urlcat": "^3.1.0"
  },
  "devDependencies": {
    "typescript": "^5.0.4"
  }
}
```

`tsconfig.json`

```json
{
  "compilerOptions": {
    "module": "nodenext",
    "moduleResolution": "nodenext",
    "strict": true
  }
}
```

This emits the following error

```
index.ts:1:20 - error TS7016: Could not find a declaration file for module 'urlcat'. 'node_modules/urlcat/dist/index.mjs' implicitly has an 'any' type.
  There are types at 'node_modules/urlcat/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'urlcat' library may need to update its package.json or typings.

1 import urlcat from "urlcat";
                     ~~~~~~~~


Found 1 error in index.ts:1
```

This PR fixes the issue.

### About `postbuild`

To find type definition file for `.mjs`, it requires `.d.mts`.
Ideally, tsup should add support for generating `.d.mts` or `.d.cts` file, but currently the feature is not implemented (https://github.com/egoist/tsup/issues/760).
So this PR copies `.d.ts` to `.d.mts` in a `postbuild` script as a workaround.