### PR TITLE
Add "types" to package.json exports to fix module type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This commit fixes the following Typescript error:

```
Could not find a declaration file for module 'urlcat'. 'foo/node_modules/urlcat/dist/index.mjs' implicitly has an 'any' type.
There are types at 'foo/urlcat/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'urlcat' library may need to update its package.json or typings.
```