### PR TITLE
add type definitions path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `npm install` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`npm test`).
  5. Format your code using the settings in .editorconfig.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This change involves adding a path to the type declaration file ('.d.ts') for the 'urlcat' module in the package.json file. Typically, TypeScript utilizes this path to ensure type safety when working with the module. This edit is necessary because TypeScript is unable to locate and utilize the type declaration file, even if it exists. This could be due to a mismatch in the paths specified in the "exports" section of the package.json file of the 'urlcat' module. As a result of this change, TypeScript will be able to correctly utilize the types from 'urlcat' in the project. It's possible that the 'urlcat' library may also need to update its package.json or type declaration files to address this issue in the future.

## Details

<!-- Please provide any further details necessary to review and test your code. -->
